### PR TITLE
Show Alert dialog adaptively base on current platform

### DIFF
--- a/packages/nartus_ui_package/lib/extensions/build_context_extension.dart
+++ b/packages/nartus_ui_package/lib/extensions/build_context_extension.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:nartus_ui_package/nartus_ui.dart';
+
+extension BuildContextExtension on BuildContext {
+  void showDialogAdaptive(
+      {Widget? title,
+      Widget? content,
+      List<Widget>? actions,
+      bool barrierDismissible = false}) {
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      if (defaultTargetPlatform == TargetPlatform.iOS) {
+        showCupertinoDialog(
+            context: this,
+            builder: (context) => CupertinoAlertDialog(
+                  title: title,
+                  content: content,
+                  actions: actions ?? [],
+                  insetAnimationCurve: Curves.easeIn,
+                ),
+            barrierDismissible: barrierDismissible);
+      } else {
+        showDialog(
+            context: this,
+            builder: (context) => AlertDialog(
+                  title: title,
+                  content: content,
+                  actions: actions ?? [],
+                ),
+            barrierDismissible: barrierDismissible);
+      }
+    });
+  }
+}

--- a/packages/nartus_ui_package/lib/nartus_ui.dart
+++ b/packages/nartus_ui_package/lib/nartus_ui.dart
@@ -23,3 +23,4 @@ export 'package:flutter/src/material/text_button.dart';
 
 export 'platform_screens.dart';
 export 'app.dart';
+export 'extensions/build_context_extension.dart';

--- a/packages/nartus_ui_package/test/extensions/build_context_extension_test.dart
+++ b/packages/nartus_ui_package/test/extensions/build_context_extension_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/cupertino.dart' show CupertinoAlertDialog;
+import 'package:flutter/material.dart' show AlertDialog;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nartus_ui_package/nartus_ui.dart';
+import '../widget_tester_extension.dart';
+
+void main() {
+  testWidgets(
+      'given platform is iOS, when showDialogAdaptive, then show CupertinoAlertDialog',
+      (widgetTester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+    int counter = 0;
+
+    Widget builder = Builder(
+      builder: (BuildContext context) {
+        context.showDialogAdaptive(
+            title: const Text('Title'),
+            content: const Center(
+              child: Text('Content'),
+            ),
+            actions: [TextButton(onPressed: () {
+              counter++;
+            }, child: Text('Action'))]);
+        return Container();
+      },
+    );
+
+    await widgetTester.wrapCupertinoAndPump(builder);
+
+    expect(find.byType(CupertinoAlertDialog), findsOneWidget);
+
+    // test action
+    await widgetTester.tap(find.text('Action'));
+
+    expect(counter, 1);
+
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets('given platform is Android, when showDialogAdaptive, then show MaterialAlertDialog', (widgetTester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+    int counter = 0;
+
+    Widget builder = Builder(
+      builder: (BuildContext context) {
+        context.showDialogAdaptive(
+            title: const Text('Title'),
+            content: const Center(
+              child: Text('Content'),
+            ),
+            actions: [TextButton(onPressed: () {
+              counter++;
+            }, child: Text('Action'))]);
+        return Container();
+      },
+    );
+
+    await widgetTester.wrapMaterialAndPump(builder);
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+
+    // test action
+    await widgetTester.tap(find.text('Action'));
+
+    expect(counter, 1);
+
+    debugDefaultTargetPlatformOverride = null;
+  });
+}

--- a/packages/nartus_ui_package/test/extensions/build_context_extension_test.dart
+++ b/packages/nartus_ui_package/test/extensions/build_context_extension_test.dart
@@ -31,6 +31,10 @@ void main() {
     expect(find.byType(CupertinoAlertDialog), findsOneWidget);
 
     // test action
+    CupertinoAlertDialog cupertinoAlertDialog = widgetTester.widget(find.byType(CupertinoAlertDialog));
+
+    expect(cupertinoAlertDialog.actions.length, 1);
+
     await widgetTester.tap(find.text('Action'));
 
     expect(counter, 1);
@@ -62,10 +66,70 @@ void main() {
     expect(find.byType(AlertDialog), findsOneWidget);
 
     // test action
+    AlertDialog alertDialog = widgetTester.widget(find.byType(AlertDialog));
+
+    expect(alertDialog.actions?.length, 1);
+
     await widgetTester.tap(find.text('Action'));
 
     expect(counter, 1);
 
     debugDefaultTargetPlatformOverride = null;
   });
+
+  testWidgets(
+      'given platform is iOS, when showDialogAdaptive without actions, then show CupertinoAlertDialog without actions',
+  (widgetTester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+    Widget builder = Builder(
+      builder: (BuildContext context) {
+        context.showDialogAdaptive(
+            title: const Text('Title'),
+            content: const Center(
+              child: Text('Content'),
+            ),);
+        return Container();
+      },
+    );
+
+    await widgetTester.wrapCupertinoAndPump(builder);
+
+    expect(find.byType(CupertinoAlertDialog), findsOneWidget);
+
+    // test action
+    CupertinoAlertDialog cupertinoAlertDialog = widgetTester.widget(find.byType(CupertinoAlertDialog));
+
+    expect(cupertinoAlertDialog.actions.length, 0);
+
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets(
+      'given platform is Android, when showDialogAdaptive without actions, then show MaterialAlertDialog without actions',
+          (widgetTester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+        Widget builder = Builder(
+          builder: (BuildContext context) {
+            context.showDialogAdaptive(
+              title: const Text('Title'),
+              content: const Center(
+                child: Text('Content'),
+              ),);
+            return Container();
+          },
+        );
+
+        await widgetTester.wrapMaterialAndPump(builder);
+
+        expect(find.byType(AlertDialog), findsOneWidget);
+
+        // test action
+        AlertDialog alertDialog = widgetTester.widget(find.byType(AlertDialog));
+
+        expect(alertDialog.actions?.length, 0);
+
+        debugDefaultTargetPlatformOverride = null;
+      });
 }

--- a/packages/nartus_ui_package/test/widget_tester_extension.dart
+++ b/packages/nartus_ui_package/test/widget_tester_extension.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+extension WidgetExtension on WidgetTester {
+  Future<void> wrapMaterialAndPump(Widget widget,
+      {bool infiniteAnimationWidget = false}) async {
+    final Widget wrapper = _MaterialWrapWidget(child: widget);
+
+    await pumpWidget(wrapper);
+    if (infiniteAnimationWidget) {
+      await pump();
+    } else {
+      await pumpAndSettle();
+    }
+  }
+
+  Future<void> wrapCupertinoAndPump(Widget widget,
+      {bool infiniteAnimationWidget = false}) async {
+    final Widget wrapper = _CupertinoWrapWidget(child: widget);
+
+    await pumpWidget(wrapper);
+    if (infiniteAnimationWidget) {
+      await pump();
+    } else {
+      await pumpAndSettle();
+    }
+  }
+}
+
+class _MaterialWrapWidget extends StatelessWidget {
+  final Widget child;
+
+  const _MaterialWrapWidget({required this.child, Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) => MaterialApp(
+        home: Scaffold(
+          body: child,
+        ),
+      );
+}
+
+class _CupertinoWrapWidget extends StatelessWidget {
+  final Widget child;
+
+  const _CupertinoWrapWidget({required this.child, Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) => CupertinoApp(
+    home: CupertinoPageScaffold(
+      child: child,
+    ),
+  );
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -170,7 +170,7 @@ packages:
     source: hosted
     version: "3.0.2"
   cupertino_icons:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: cupertino_icons
       url: "https://pub.dartlang.org"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -254,7 +254,7 @@ packages:
     source: hosted
     version: "1.0.1"
   flutter:
-    dependency: "direct main"
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,13 +27,6 @@ environment:
 # the latest version available on pub.dev. To see which dependencies have newer
 # versions available, run `flutter pub outdated`.
 dependencies:
-  flutter:
-    sdk: flutter
-
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.5
   firebase_auth: ^3.6.3
   firebase_core: ^1.20.1
   google_maps_flutter: ^2.1.10

--- a/scripts/check_code_coverage.sh
+++ b/scripts/check_code_coverage.sh
@@ -2,6 +2,8 @@
 
 root=$(pwd)
 
+rm -r coverage/
+
 flutter pub get
 flutter pub run build_runner build --delete-conflicting-outputs
 flutter test --coverage


### PR DESCRIPTION
if current platform is iOS, use CupertinoAlertDialog, else use MaterialAlertDialog

Sample code
``` 
context.showDialogAdaptive(
              title: Text('Title'),
              content: Text('This is a sample content'),
              actions: [
                TextButton(onPressed: () => Navigator.of(context).pop(), child: Text('Action!'))
              ]
            );
```