### PR TITLE
Fix: starting animation in build method

### DIFF
--- a/packages/nartus_ui_package/lib/widgets/text_error_label/text_and_error_label.dart
+++ b/packages/nartus_ui_package/lib/widgets/text_error_label/text_and_error_label.dart
@@ -36,18 +36,23 @@ class _TextAndErrorLabelState extends State<TextAndErrorLabel>
   @override
   void dispose() {
     super.dispose();
-
     _controller.dispose();
   }
 
   @override
-  Widget build(BuildContext context) {
-    if (widget._showError) {
-      _controller.forward();
-    } else {
-      _controller.reverse();
+  void didUpdateWidget(covariant TextAndErrorLabel oldWidget) {
+    if (widget._showError != oldWidget._showError) {
+      if (widget._showError) {
+        _controller.forward();
+      } else {
+        _controller.reverse();
+      }
     }
+    super.didUpdateWidget(oldWidget);
+  }
 
+  @override
+  Widget build(BuildContext context) {      
     return Card(
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.all(Radius.circular(NartusDimens.padding24)),


### PR DESCRIPTION
TextAndErrorLabel rebuilds continuously but showError don't  change:
- [x] move code start animation from build to didUpdateWidget
- [x] check if showError is different from old state, if true then start animation